### PR TITLE
Make regex string a raw string in python

### DIFF
--- a/crates/target_python/src/lib.rs
+++ b/crates/target_python/src/lib.rs
@@ -238,7 +238,7 @@ impl jtd_codegen::target::Target for Target {
                 writeln!(out, "    return data.to_json_data()")?;
                 writeln!(out)?;
                 writeln!(out, "def _parse_rfc3339(s: str) -> datetime:")?;
-                writeln!(out, "    datetime_re = '^(\\d{{4}})-(\\d{{2}})-(\\d{{2}})[tT](\\d{{2}}):(\\d{{2}}):(\\d{{2}})(\\.\\d+)?([zZ]|((\\+|-)(\\d{{2}}):(\\d{{2}})))$'")?;
+                writeln!(out, "    datetime_re = r'^(\\d{{4}})-(\\d{{2}})-(\\d{{2}})[tT](\\d{{2}}):(\\d{{2}}):(\\d{{2}})(\\.\\d+)?([zZ]|((\\+|-)(\\d{{2}}):(\\d{{2}})))$'")?;
                 writeln!(out, "    match = re.match(datetime_re, s)")?;
                 writeln!(out, "    if not match:")?;
                 writeln!(


### PR DESCRIPTION
TL;DR: This prevents `SyntaxError: invalid escape sequence \d`

Longer explanation: Python 3 considers strings to be Unicode rather than ASCII. The `\` in `\d` is interpreted as the beginning of a Unicode character escape sequence rather than left as is as part of the Regex. `\d` is not a valid Unicode sequence so it was left as is so far with a DeprecationWarning thrown. In Python 3.9+ (maybe earlier, haven't tested) it's now a SyntaxError. The easy solution which I have applied here is to use a raw string literal instead of a typical string literal as raw string literals treat backslashes within the string as "just backslashes" and not escaping characters.